### PR TITLE
Fix backend image chapter extraction

### DIFF
--- a/backend/src/services/epubService.ts
+++ b/backend/src/services/epubService.ts
@@ -137,7 +137,8 @@ export class EpubService {
           // Clean up HTML and extract text content
           const cleanText = this.cleanHtmlContent(text || '');
           if (!cleanText || cleanText.trim().length === 0) {
-            reject(new Error(`No content found in ${href}`));
+            console.warn(`Empty content for ${href} - possible image-only chapter`);
+            resolve('');
           } else {
             resolve(cleanText);
           }
@@ -159,8 +160,10 @@ export class EpubService {
   }
 
   private cleanHtmlContent(html: string): string {
-    // Remove HTML tags and clean up content
+    // Replace images with a placeholder then remove other HTML tags
     return html
+      .replace(/<img[^>]*alt=["']?([^"'>]*)["']?[^>]*>/gi, (_, alt) => alt ? `[Image: ${alt}]` : '[Image]')
+      .replace(/<img[^>]*>/gi, '[Image]')
       .replace(/<[^>]*>/g, '')
       .replace(/&nbsp;/g, ' ')
       .replace(/&amp;/g, '&')


### PR DESCRIPTION
## Summary
- handle chapters that only contain images
- replace `<img>` tags with `[Image]` placeholder text

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684170dab1508333b893f302019108df